### PR TITLE
Surpressing unnecessary errors

### DIFF
--- a/nrscope/hdr/nrscope_worker.h
+++ b/nrscope/hdr/nrscope_worker.h
@@ -17,6 +17,7 @@ public:
   RachDecoder rach_decoder; 
   SIBsDecoder sibs_decoder;
   std::vector<std::unique_ptr <DCIDecoder> > dci_decoders;
+  bool initializing;
 
   /* Job indicator */
   sem_t smph_has_job; 

--- a/nrscope/src/libs/radio_nr.cc
+++ b/nrscope/src/libs/radio_nr.cc
@@ -881,7 +881,7 @@ int Radio::DecodeAndProcess(){
 
       if (task_scheduler_nrscope.AssignTask(sf_round, slot, outcome, rx_buffer) 
           < SRSRAN_SUCCESS) {
-        ERROR("Assign task failed");
+        // ERROR("Assign task failed");
         /* Push empty slot result to the queue */
         SlotResult empty_result = {};
         empty_result.sf_round = sf_round;

--- a/nrscope/src/libs/task_scheduler.cc
+++ b/nrscope/src/libs/task_scheduler.cc
@@ -427,7 +427,11 @@ int TaskSchedulerNRScope::AssignTask(uint64_t sf_round,
     }
   }
   
-  if (!found_worker) {
+  if (!found_worker && workers[nof_workers-1].get()->initializing) {
+    std::cout << "Workers are initializing, skip sf_rount: " << sf_round << 
+      ", sfn: " << outcome.sfn << ", slot: " << slot.idx ;
+    return SRSRAN_ERROR;
+  } else if (!found_worker) {
     ERROR("No available worker, if this constantly happens not in the intial"
           "stage (SIBs, RACH, DCI decoders initialization), please consider "
           "increasing the number of workers.");


### PR DESCRIPTION
This pull request has two modifications:
* Surpressing unnecessary errors when the workers are loading configurations from newly decoded RRC messages (SIB and RACH decoding) through a `initializing` variable.
* Decoupling the uplink bwp configuration from the original downlink bwp configuration, as they may be configured independently.