### PR TITLE
Enabling 100mhz cell decoding with X310 UBX/CBX

### DIFF
--- a/lib/src/phy/rf/rf_uhd_imp.cc
+++ b/lib/src/phy/rf/rf_uhd_imp.cc
@@ -1315,14 +1315,12 @@ int rf_uhd_recv_with_time_multi(void*    h,
     }
   }
 
-  std::cout << "nsamples: " << nsamples << std::endl;
   // Receive stream in multiple blocks
   while (rxd_samples_total < nsamples and trials < RF_UHD_IMP_MAX_RX_TRIALS) {
     void* buffs_ptr[SRSRAN_MAX_CHANNELS] = {};
 
     size_t num_samps_left = nsamples - rxd_samples_total;
     size_t num_rx_samples = SRSRAN_MIN(handler->rx_nof_samples, num_samps_left);
-    std::cout << "num_rx_samples: " << num_rx_samples << std::endl;
 
     for (uint32_t i = 0; i < handler->nof_rx_channels; i++) {
       if (data[i] != nullptr) {
@@ -1346,10 +1344,8 @@ int rf_uhd_recv_with_time_multi(void*    h,
     uhd::rx_metadata_t::error_code_t& error_code = md.error_code;
 
     rxd_samples_total += rxd_samples;
-    std::cout << "rxd_samples_total: " << rxd_samples_total << std::endl;
 
     trials++;
-    std::cout << "trials: " << trials << std::endl;
 
     if (error_code == uhd::rx_metadata_t::ERROR_CODE_OVERFLOW) {
       log_overflow(handler);

--- a/lib/src/phy/rf/rf_uhd_imp.cc
+++ b/lib/src/phy/rf/rf_uhd_imp.cc
@@ -1315,12 +1315,14 @@ int rf_uhd_recv_with_time_multi(void*    h,
     }
   }
 
+  std::cout << "nsamples: " << nsamples << std::endl;
   // Receive stream in multiple blocks
   while (rxd_samples_total < nsamples and trials < RF_UHD_IMP_MAX_RX_TRIALS) {
     void* buffs_ptr[SRSRAN_MAX_CHANNELS] = {};
 
     size_t num_samps_left = nsamples - rxd_samples_total;
     size_t num_rx_samples = SRSRAN_MIN(handler->rx_nof_samples, num_samps_left);
+    std::cout << "num_rx_samples: " << num_rx_samples << std::endl;
 
     for (uint32_t i = 0; i < handler->nof_rx_channels; i++) {
       if (data[i] != nullptr) {
@@ -1344,7 +1346,10 @@ int rf_uhd_recv_with_time_multi(void*    h,
     uhd::rx_metadata_t::error_code_t& error_code = md.error_code;
 
     rxd_samples_total += rxd_samples;
+    std::cout << "rxd_samples_total: " << rxd_samples_total << std::endl;
+
     trials++;
+    std::cout << "trials: " << trials << std::endl;
 
     if (error_code == uhd::rx_metadata_t::ERROR_CODE_OVERFLOW) {
       log_overflow(handler);

--- a/lib/src/phy/sync/ssb.c
+++ b/lib/src/phy/sync/ssb.c
@@ -1565,7 +1565,6 @@ int srsran_ssb_find(srsran_ssb_t*                  q,
 
   // Set the PBCH message result with default value (CRC unmatched), meaning no cell is found
   SRSRAN_MEM_ZERO(pbch_msg, srsran_pbch_msg_nr_t, 1);
-  printf("q->ssb_sz: %d, q->sf_sz: %d\n", q->ssb_sz, q->sf_sz);
 
   // Copy tail from previous execution into the start of this
   srsran_vec_cf_copy(q->sf_buffer, &q->sf_buffer[q->sf_sz], q->ssb_sz);

--- a/lib/src/phy/sync/ssb.c
+++ b/lib/src/phy/sync/ssb.c
@@ -505,7 +505,6 @@ int srsran_ssb_set_cfg(srsran_ssb_t* q, const srsran_ssb_cfg_t* cfg)
   q->cfg       = *cfg;
   q->symbol_sz = symbol_sz;
   q->sf_sz     = (uint32_t)round(1e-3 * cfg->srate_hz);
-  printf("q->sf_sz in ssb.c: %d\n", q->sf_sz);
   q->ssb_sz    = SRSRAN_SSB_DURATION_NSYMB * (q->symbol_sz + q->cp_sz);
 
   // Initialise correlation

--- a/lib/src/phy/sync/ssb.c
+++ b/lib/src/phy/sync/ssb.c
@@ -42,7 +42,7 @@
  * Correlation size in function of the symbol size. It selects a power of two number at least 8 times bigger than the
  * given symbol size but not bigger than 2^13 points.
  */
-#define SSB_CORR_SZ(SYMB_SZ) SRSRAN_MIN(1U << (uint32_t)ceil(log2((double)(SYMB_SZ)) + 3.0), 1U << 13U)
+#define SSB_CORR_SZ(SYMB_SZ) SRSRAN_MIN(1U << (uint32_t)ceil(log2((double)(SYMB_SZ)) + 3.0), 1U << 14U)
 
 /*
  * Default NR-PBCH DMRS normalised correlation (RSRP/EPRE) threshold
@@ -505,6 +505,7 @@ int srsran_ssb_set_cfg(srsran_ssb_t* q, const srsran_ssb_cfg_t* cfg)
   q->cfg       = *cfg;
   q->symbol_sz = symbol_sz;
   q->sf_sz     = (uint32_t)round(1e-3 * cfg->srate_hz);
+  printf("q->sf_sz in ssb.c: %d\n", q->sf_sz);
   q->ssb_sz    = SRSRAN_SSB_DURATION_NSYMB * (q->symbol_sz + q->cp_sz);
 
   // Initialise correlation
@@ -1565,6 +1566,7 @@ int srsran_ssb_find(srsran_ssb_t*                  q,
 
   // Set the PBCH message result with default value (CRC unmatched), meaning no cell is found
   SRSRAN_MEM_ZERO(pbch_msg, srsran_pbch_msg_nr_t, 1);
+  printf("q->ssb_sz: %d, q->sf_sz: %d\n", q->ssb_sz, q->sf_sz);
 
   // Copy tail from previous execution into the start of this
   srsran_vec_cf_copy(q->sf_buffer, &q->sf_buffer[q->sf_sz], q->ssb_sz);

--- a/lib/src/phy/ue/ue_sync_nr.c
+++ b/lib/src/phy/ue/ue_sync_nr.c
@@ -249,6 +249,7 @@ static int ue_sync_nr_recv(srsran_ue_sync_nr_t* q, cf_t** buffer, srsran_timesta
 
   uint32_t buffer_offset = 0;
   uint32_t nof_samples   = q->sf_sz;
+  printf("nof_samples: %d\n", nof_samples);
 
   if (q->next_rf_sample_offset > 0) {
     // Discard a number of samples from RF

--- a/lib/src/phy/ue/ue_sync_nr.c
+++ b/lib/src/phy/ue/ue_sync_nr.c
@@ -249,7 +249,6 @@ static int ue_sync_nr_recv(srsran_ue_sync_nr_t* q, cf_t** buffer, srsran_timesta
 
   uint32_t buffer_offset = 0;
   uint32_t nof_samples   = q->sf_sz;
-  printf("nof_samples: %d\n", nof_samples);
 
   if (q->next_rf_sample_offset > 0) {
     // Discard a number of samples from RF

--- a/lib/src/radio/radio.cc
+++ b/lib/src/radio/radio.cc
@@ -310,7 +310,7 @@ bool radio::rx_now(rf_buffer_interface& buffer, rf_timestamp_interface& rxd_time
 
   // Calculate number of samples, considering the decimation ratio
   uint32_t nof_samples = buffer.get_nof_samples() * ratio;
-  std::cout << "nof_samples: " << nof_samples << std::endl;
+
   // Check decimation buffer protection
   if (ratio > 1 && nof_samples > rx_buffer[0].size()) {
     // This is a corner case that could happen during sample rate change transitions, as it does not have a negative

--- a/lib/src/radio/radio.cc
+++ b/lib/src/radio/radio.cc
@@ -310,7 +310,7 @@ bool radio::rx_now(rf_buffer_interface& buffer, rf_timestamp_interface& rxd_time
 
   // Calculate number of samples, considering the decimation ratio
   uint32_t nof_samples = buffer.get_nof_samples() * ratio;
-  // std::cout << "nof_samples: " << nof_samples << std::endl;
+  std::cout << "nof_samples: " << nof_samples << std::endl;
   // Check decimation buffer protection
   if (ratio > 1 && nof_samples > rx_buffer[0].size()) {
     // This is a corner case that could happen during sample rate change transitions, as it does not have a negative

--- a/nrscope/config/config_100mhz.yaml
+++ b/nrscope/config/config_100mhz.yaml
@@ -1,0 +1,50 @@
+nof_usrp_dev: 1
+usrp_setting_0:
+  ssb_freq: 2506950000 # Set to the ssb frequency of the cell, could be obtained with the cell scan function
+  rf_args: "clock=external,type=x300" # For B210
+  # rf_args: "clock=external,type=x300,serial=32B0F2F,master_clock_rate=200000000,sampling_rate=25000000" ## For TwinRX daughterboard
+  # rf_args: "clock=external,type=x300,sampling_rate=23040000" ## For CBX daughterboard
+  rx_gain: 31.5 # for x310 CBX, max rx gain is 31.5, for b210, it's around 80, for x310 TwinRX, max rx gain is 90
+  min_rx_gain: 0
+  max_rx_gain: 31.5
+  srate_hz: 184320000 # the sampling rate of USRP, integer division of 200MHz for TwinRX, and 5G sampling rate for CBX: 11520000 or 23040000
+  srsran_srate_hz: 184320000 # the sampling for real signal processing, should be in 5G sampling rate, multiple of 1.92 MHz. 
+  nof_carriers: 1 # srsRAN rf setting, always set to be 1 for now. 
+  nof_antennas: 1 # srsRAN rf setting, always set to be 1 for now.
+  scs_index: 1 #(0: 15kHz, 1: 30kHz, ..., the u in standard)
+  rf_log_level: "debug"
+  nof_rnti_worker_groups: 4 # number of of threads for DCI decoding, each will divide the UEs into small groups
+  nof_bwps: 1 # number of BWP of the cell
+  nof_workers: 10 # using worker pool to asynchronously process the slot data
+  cpu_affinity: false # pin the worker's thread into CPU or not.
+
+  log_name: "a.csv"
+  google_dataset_id: "ngscope5g_dci_log_wanhr"
+
+# usrp_setting_1:
+#   ssb_freq: 622850000 # Set to the ssb frequency of the cell, could be obtained with the cell scan function
+#   rf_args: "clock=external,type=b200" # For B210
+#   # rf_args: "clock=external,type=x300,serial=32B0F2F,master_clock_rate=200000000,sampling_rate=25000000" ## For TwinRX daughterboard
+#   # rf_args: "clock=external,type=x300,sampling_rate=23040000" ## For CBX daughterboard
+#   rx_gain: 75 # for x310 CBX, max rx gain is 31.5, for b210, it's around 80, for x310 TwinRX, max rx gain is 90
+#   min_rx_gain: 0
+#   max_rx_gain: 80
+#   srate_hz: 15360000 # the sampling rate of USRP, integer division of 200MHz for TwinRX, and 5G sampling rate for CBX: 11520000 or 23040000
+#   srsran_srate_hz: 15360000 # the sampling for real signal processing, should be in 5G sampling rate, multiple of 1.92 MHz. 
+#   nof_carriers: 1 # srsRAN rf setting, always set to be 1 for now. 
+#   nof_antennas: 1 # srsRAN rf setting, always set to be 1 for now.
+#   scs_index: 0 #(0: 15kHz, 1: 30kHz, ..., the u in standard)
+#   rf_log_level: "debug"
+#   nof_rnti_worker_groups: 4 # number of of threads for DCI decoding, each will divide the UEs into small groups
+#   nof_bwps: 1 # number of BWP of the cell
+#   nof_workers: 4 # using worker pool to asynchronously process the slot data
+#   cpu_affinity: false # pin the worker's thread into CPU or not.
+
+#   log_name: "b.csv"
+#   google_dataset_id: "ngscope5g_dci_log_wanhr"
+
+log_config:
+  local_log: true
+  push_to_google: false
+  google_service_account_credential: "/home/wanhr/Downloads/nsf-2223556-222187-02b924918c95.json"
+

--- a/nrscope/config/config_100mhz.yaml
+++ b/nrscope/config/config_100mhz.yaml
@@ -15,7 +15,7 @@ usrp_setting_0:
   rf_log_level: "debug"
   nof_rnti_worker_groups: 4 # number of of threads for DCI decoding, each will divide the UEs into small groups
   nof_bwps: 1 # number of BWP of the cell
-  nof_workers: 10 # using worker pool to asynchronously process the slot data
+  nof_workers: 4 # using worker pool to asynchronously process the slot data
   cpu_affinity: false # pin the worker's thread into CPU or not.
 
   log_name: "a.csv"

--- a/nrscope/src/libs/radio_nr.cc
+++ b/nrscope/src/libs/radio_nr.cc
@@ -24,7 +24,7 @@ Radio::Radio() :
   nof_trials = 2000;
   nof_trials_scan = 200;
   sf_round = 0;
-  srsran_searcher_args_t.max_srate_hz = 92.16e6;
+  srsran_searcher_args_t.max_srate_hz = 184.32e6;
   srsran_searcher_args_t.ssb_min_scs = srsran_subcarrier_spacing_15kHz;
   srsran_searcher.init(srsran_searcher_args_t);
 
@@ -684,8 +684,7 @@ static int slot_sync_recv_callback(void* ptr,
 
   cf_t* buffer_ptr[SRSRAN_MAX_CHANNELS] = {};
   buffer_ptr[0]                         = buffer[0];
-  // std::cout << "[xuyang debug 3] find fetch nsamples: " 
-  //    << nsamples << std::endl;
+  std::cout << "[xuyang debug 3] find fetch nsamples: " << nsamples << std::endl;
   srsran::rf_buffer_t rf_buffer(buffer_ptr, nsamples);
 
   srsran::rf_timestamp_t a;

--- a/nrscope/src/libs/radio_nr.cc
+++ b/nrscope/src/libs/radio_nr.cc
@@ -3,7 +3,7 @@
 #include <semaphore>
 #include <chrono>
 
-#define RING_BUF_SIZE 10000
+#define RING_BUF_SIZE 10
 #define RING_BUF_MODULUS (RING_BUF_SIZE - 1)
 
 static SRSRAN_AGC_CALLBACK(radio_set_rx_gain_wrapper)
@@ -684,7 +684,7 @@ static int slot_sync_recv_callback(void* ptr,
 
   cf_t* buffer_ptr[SRSRAN_MAX_CHANNELS] = {};
   buffer_ptr[0]                         = buffer[0];
-  std::cout << "[xuyang debug 3] find fetch nsamples: " << nsamples << std::endl;
+  // std::cout << "[xuyang debug 3] find fetch nsamples: " << nsamples << std::endl;
   srsran::rf_buffer_t rf_buffer(buffer_ptr, nsamples);
 
   srsran::rf_timestamp_t a;
@@ -786,8 +786,8 @@ int Radio::FetchAndResample(){
 
     std::cout << "current_produce_at: " << (!in_sync ? 0 : 
         (next_produce_at % RING_BUF_MODULUS + 1)) << std::endl;
-      std::cout << "current_produce_ptr: " << (rf_buffer_t.to_cf_t())[0] << 
-      std::endl;
+    std::cout << "current_produce_ptr: " << (rf_buffer_t.to_cf_t())[0] << 
+        std::endl;
 
     /* note fetching the raw samples will temporarily touch area out of the 
       target sf boundary yet after resampling, all meaningful data will reside 

--- a/nrscope/src/libs/task_scheduler.cc
+++ b/nrscope/src/libs/task_scheduler.cc
@@ -429,7 +429,7 @@ int TaskSchedulerNRScope::AssignTask(uint64_t sf_round,
   
   if (!found_worker && workers[nof_workers-1].get()->initializing) {
     std::cout << "Workers are initializing, skip sf_rount: " << sf_round << 
-      ", sfn: " << outcome.sfn << ", slot: " << slot.idx ;
+      ", sfn: " << outcome.sfn << ", slot: " << slot.idx << std::endl;
     return SRSRAN_ERROR;
   } else if (!found_worker) {
     ERROR("No available worker, if this constantly happens not in the intial"


### PR DESCRIPTION
With some small modifications, now the code is able to decode the MIB, SIB and RACH from the 100Mhz cell using X310 USRP with UBX and CBX daughterboard. The sampling rate should be 184.32MHz, and a 10Gbps Ethernet or PCIe interface should be used as the required data rate is around 708 MBytes/s (5.66 Gbps). 
Also, a `config.yaml` file for the 100MHz cell is provided, please check `/nrscope/config/config_100mhz.yaml`.

But the live UEs are likely to be configured with a secondary cell (for carrier aggregation) immediately after the RACH, the next step is to somehow get this information, either through ad-hoc/database or through guessing.