### PR TITLE
Enabling carrier aggregation DCI decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,21 @@ NR-Scope and NG-Scope are open source products of NSF Award CNS-2223556 (IMR: MT
 The main features are as follows:
 
 1. Supports 5G SA cells with 15kHz and 30kHz SCS, tested with 10MHz, 15 MHz, 20MHz, 40MHz and 100MHz cell bandwidth.
-2. 5G SA cell search and MIB decoding.
-3. SIB 1 and all other SIBs decoding.
-4. RRCSetup (MSG 4) decoding for continuously UE attatch detection.
-5. Threaded DCI decoding for detected UEs.
-6. SIB, RRCSetup and DCI decoding are threaded for performance and independent processing.
-7. Can concurrently decode up to 64 UEs (max number we can create for now) in the same base station.
-8. Accurate DCIs, PRB and bit rate estimation for each UEs (please stay tuned for our paper).
-9. Local logging functions in `.csv` file and remote google BigQuery uploading function in BigQuery table.
-10. Support using multiple USRPs to decode multiple base stations independently, each has its own log.
-11. Cell search for all possible frequencies in a separate file and the results are stored in `.csv` log file.
-12. Non-initial (BWP id > 0) and plaintext (configured in SIB 1 or MSG 4) BWPs decoding in separate DCI decoder threads.
-13. Threaded resampling function for better-fidelity TwinRX USRP X310 daughterboard (better signal quality but doesn't support 5G sampling rate without resampling).
-14. Worker pool function is implemented. Each worker works on the slot data asynchronously. Now the processing doesn't need to keep up with the short slot time, and the throughput is increase through more workers.
-15. Stay tuned... 😄
+2. Carrier aggregation decoding, NR-Scope would use one SDR to try to decode both carrier aggregated and not carrier aggregated UEs within the RAN. Tested in commercial T-Mobile 15MHz FDD and 100MHz TDD cells.
+3. 5G SA cell search and MIB decoding.
+4. SIB 1 and all other SIBs decoding.
+5. RRCSetup (MSG 4) decoding for continuously UE attatch detection.
+6. Threaded DCI decoding for detected UEs.
+7. SIB, RRCSetup and DCI decoding are threaded for performance and independent processing.
+8. Can concurrently decode up to 64 UEs (max number we can create for now) in the same base station.
+9. Accurate DCIs, PRB and bit rate estimation for each UEs (please stay tuned for our paper).
+10. Local logging functions in `.csv` file and remote google BigQuery uploading function in BigQuery table.
+11. Support using multiple USRPs to decode multiple base stations independently, each has its own log.
+12. Cell search for all possible frequencies in a separate file and the results are stored in `.csv` log file.
+13. Non-initial (BWP id > 0) and plaintext (configured in SIB 1 or MSG 4) BWPs decoding in separate DCI decoder threads.
+14. Threaded resampling function for better-fidelity TwinRX USRP X310 daughterboard (better signal quality but doesn't support 5G sampling rate without resampling).
+15. Worker pool function is implemented. Each worker works on the slot data asynchronously. Now the processing doesn't need to keep up with the short slot time, and the throughput is increase through more workers.
+16. Stay tuned... 😄
 
 Please refer to the [wiki page](https://github.com/PrincetonUniversity/NG-Scope-5G/wiki) for more feature description and documentation.
 

--- a/lib/include/srsran/phy/phch/dci_nr.h
+++ b/lib/include/srsran/phy/phch/dci_nr.h
@@ -134,7 +134,7 @@ typedef struct SRSRAN_API {
  */
 typedef struct SRSRAN_API {
   srsran_dci_ctx_t ctx; ///< DCI context
-  uint8_t          payload[50];
+  uint8_t          payload[80];
   uint32_t         nof_bits;
 } srsran_dci_msg_nr_t;
 

--- a/lib/src/phy/phch/dci_nr.c
+++ b/lib/src/phy/phch/dci_nr.c
@@ -400,50 +400,50 @@ static uint32_t dci_nr_format_0_1_sizeof(const srsran_dci_cfg_nr_t* cfg, srsran_
 
   // Identifier for DCI formats – 1 bit
   count += 1;
-  printf("dci_size: %u, DCI format added size: %u\n", count, 1);
+  // printf("dci_size: %u, DCI format added size: %u\n", count, 1);
 
   // Carrier indicator – 0 or 3 bits
   count += cfg->carrier_indicator_size;
-  printf("dci_size: %u, Carrier Indicator added size: %u\n", count, cfg->carrier_indicator_size);
+  // printf("dci_size: %u, Carrier Indicator added size: %u\n", count, cfg->carrier_indicator_size);
 
   // UL/SUL indicator – 0 bit for UEs not configured with supplementaryUplink ... otherwise, 1 bit
   count += cfg->enable_sul ? 1 : 0;
-  printf("dci_size: %u, UL/SUL Indicator added size: %u\n", count, cfg->enable_sul ? 1 : 0);
+  // printf("dci_size: %u, UL/SUL Indicator added size: %u\n", count, cfg->enable_sul ? 1 : 0);
 
   // Bandwidth part indicator – 0, 1 or 2 bits
   count += dci_nr_bwp_id_size(cfg->nof_ul_bwp);
-  printf("dci_size: %u, BWP Indicator added size: %u\n", count, dci_nr_bwp_id_size(cfg->nof_ul_bwp));
+  // printf("dci_size: %u, BWP Indicator added size: %u\n", count, dci_nr_bwp_id_size(cfg->nof_ul_bwp));
 
   // Frequency domain resource assignment
   count += dci_nr_freq_resource_size(cfg->pusch_alloc_type, cfg->nof_rb_groups, cfg->bwp_ul_active_bw);
-  printf("dci_size: %u, Freq domain Indicator added size: %u\n", count, dci_nr_freq_resource_size(cfg->pusch_alloc_type, cfg->nof_rb_groups, cfg->bwp_ul_active_bw));
+  // printf("dci_size: %u, Freq domain Indicator added size: %u\n", count, dci_nr_freq_resource_size(cfg->pusch_alloc_type, cfg->nof_rb_groups, cfg->bwp_ul_active_bw));
 
   // Time domain resource assigment - 0, 1, 2, 3, or 4 bits
   count += dci_nr_time_res_size(cfg->nof_ul_time_res);
-  printf("dci_size: %u, Time domain Indicator added size: %u\n", count, dci_nr_time_res_size(cfg->nof_ul_time_res));
+  // printf("dci_size: %u, Time domain Indicator added size: %u\n", count, dci_nr_time_res_size(cfg->nof_ul_time_res));
   // Frequency hopping flag - 0 or 1 bit:
   if (cfg->pusch_alloc_type == srsran_resource_alloc_type0 || !cfg->enable_hopping) {
     count += 0;
   } else {
     count += 1;
   }
-  printf("dci_size: %u, frequency hopping added size: %u\n", count, (cfg->pusch_alloc_type == srsran_resource_alloc_type0 || !cfg->enable_hopping)?0:1);
+  // printf("dci_size: %u, frequency hopping added size: %u\n", count, (cfg->pusch_alloc_type == srsran_resource_alloc_type0 || !cfg->enable_hopping)?0:1);
 
   // Modulation and coding scheme – 5 bits
   count += 5;
-  printf("dci_size: %u, MCS Indicator added size: %u\n", count, 5);
+  // printf("dci_size: %u, MCS Indicator added size: %u\n", count, 5);
 
   // New data indicator – 1 bit
   count += 1;
-  printf("dci_size: %u, new data Indicator added size: %u\n", count, 1);
+  // printf("dci_size: %u, new data Indicator added size: %u\n", count, 1);
 
   // Redundancy version – 2 bits
   count += 2;
-  printf("dci_size: %u, redundancy version Indicator added size: %u\n", count, 2);
+  // printf("dci_size: %u, redundancy version Indicator added size: %u\n", count, 2);
 
   // HARQ process number – 4 bits
   count += 4;
-  printf("dci_size: %u, HARQ process number added size: %u\n", count, 4);
+  // printf("dci_size: %u, HARQ process number added size: %u\n", count, 4);
 
   // 1st DAI - 1 or 2 bits
   if (cfg->harq_ack_codebok == srsran_pdsch_harq_ack_codebook_semi_static) {
@@ -451,65 +451,65 @@ static uint32_t dci_nr_format_0_1_sizeof(const srsran_dci_cfg_nr_t* cfg, srsran_
   } else {
     count += 2;
   }
-  printf("dci_size: %u, DAI 1 number added size: %u\n", count, (cfg->harq_ack_codebok == srsran_pdsch_harq_ack_codebook_semi_static)?1:2);
+  // printf("dci_size: %u, DAI 1 number added size: %u\n", count, (cfg->harq_ack_codebok == srsran_pdsch_harq_ack_codebook_semi_static)?1:2);
 
   // 2st DAI - 0 or 2 bits
   if (cfg->dynamic_dual_harq_ack_codebook) {
     count += 2;
   }
-  printf("dci_size: %u, DAI 2 number added size: %u\n", count, cfg->dynamic_dual_harq_ack_codebook?2:0);
+  // printf("dci_size: %u, DAI 2 number added size: %u\n", count, cfg->dynamic_dual_harq_ack_codebook?2:0);
 
   // TPC command for scheduled PUSCH – 2 bits
   count += 2;
-  printf("dci_size: %u, TPC number added size: %u\n", count, 2);
+  // printf("dci_size: %u, TPC number added size: %u\n", count, 2);
 
   // SRS resource indicator
   count += dci_nr_srs_id_size(cfg);
-  printf("dci_size: %u, SRS number added size: %u\n", count, dci_nr_srs_id_size(cfg));
+  // printf("dci_size: %u, SRS number added size: %u\n", count, dci_nr_srs_id_size(cfg));
 
   // Precoding information and number of layers
   if (!cfg->pusch_tx_config_non_codebook && cfg->nof_ul_layers > 1) {
     ERROR("Precoding information > 1. Not implemented");
     return 0;
   }
-  printf("dci_size: %u, Precoding number added size: %u\n", count, 0);
+  // printf("dci_size: %u, Precoding number added size: %u\n", count, 0);
 
   // Antenna ports
   count += dci_nr_ul_ports_size(cfg);
-  printf("dci_size: %u, Antenna ports number added size: %u\n", count, dci_nr_ul_ports_size(cfg));
+  // printf("dci_size: %u, Antenna ports number added size: %u\n", count, dci_nr_ul_ports_size(cfg));
 
   // SRS request - 2 or 3 bits
   count += cfg->enable_sul ? 3 : 2;
-  printf("dci_size: %u, SRS request number added size: %u\n", count, cfg->enable_sul ? 3 : 2);
+  // printf("dci_size: %u, SRS request number added size: %u\n", count, cfg->enable_sul ? 3 : 2);
 
   // CSI request - 0, 1, 2, 3, 4, 5, or 6 bits
   count += SRSRAN_MIN(6, cfg->report_trigger_size);
-  printf("dci_size: %u, CSI request added size: %u\n", count, SRSRAN_MIN(6, cfg->report_trigger_size));
+  // printf("dci_size: %u, CSI request added size: %u\n", count, SRSRAN_MIN(6, cfg->report_trigger_size));
 
   // CBG transmission information - 0, 2, 4, 6, or 8 bits
   count += cfg->pusch_nof_cbg;
-  printf("dci_size: %u, CBG added size: %u\n", count, cfg->pusch_nof_cbg);
+  // printf("dci_size: %u, CBG added size: %u\n", count, cfg->pusch_nof_cbg);
 
   // PTRS-DMRS association - 0 or 2 bits
   count += dci_nr_ptrs_size(cfg);
-  printf("dci_size: %u, PTRS-DMRS added size: %u\n", count, dci_nr_ptrs_size(cfg));
+  // printf("dci_size: %u, PTRS-DMRS added size: %u\n", count, dci_nr_ptrs_size(cfg));
 
   // beta_offset indicator – 0 or 2 bits
   if (cfg->pusch_dynamic_betas) {
     count += 2;
   }
-  printf("dci_size: %u, beta_offset added size: %u\n", count, cfg->pusch_dynamic_betas?2:0);
+  // printf("dci_size: %u, beta_offset added size: %u\n", count, cfg->pusch_dynamic_betas?2:0);
 
   // DMRS sequence initialization - 0 or 1 bit
   if (!cfg->enable_transform_precoding) {
     count += 1;
   }
-  printf("dci_size: %u, DMRS sequence initialization added size: %u\n", count, (!cfg->enable_transform_precoding)?1:0);
+  // printf("dci_size: %u, DMRS sequence initialization added size: %u\n", count, (!cfg->enable_transform_precoding)?1:0);
 
   // UL-SCH indicator – 1 bit
   count += 1;
-  printf("dci_size: %u, UL-SCH added size: %u\n", count, 1);
-  printf("final dci_size: %u\n", count);
+  // printf("dci_size: %u, UL-SCH added size: %u\n", count, 1);
+  // printf("final dci_size: %u\n", count);
   return count;
 }
 
@@ -1349,33 +1349,33 @@ static uint32_t dci_nr_format_1_1_sizeof(const srsran_dci_cfg_nr_t* cfg, srsran_
 
   // Identifier for DCI formats – 1 bits
   count += 1;
-  printf("dci_size: %u, dci_format added size: %u\n", count, 1);
+  // printf("dci_size: %u, dci_format added size: %u\n", count, 1);
 
   // Carrier indicator – 0 or 3 bits
   count += (int)cfg->carrier_indicator_size;
-  printf("dci_size: %u, carrier_indicator added size: %u\n", count, (int)cfg->carrier_indicator_size);
+  // printf("dci_size: %u, carrier_indicator added size: %u\n", count, (int)cfg->carrier_indicator_size);
 
   // Bandwidth part indicator – 0, 1 or 2 bits
   count += (int)dci_nr_bwp_id_size(cfg->nof_dl_bwp);
-  printf("dci_size: %u, bwp_indicator added size: %u\n", count, (int)dci_nr_bwp_id_size(cfg->nof_dl_bwp));
+  // printf("dci_size: %u, bwp_indicator added size: %u\n", count, (int)dci_nr_bwp_id_size(cfg->nof_dl_bwp));
 
   // Frequency domain resource assignment
   count += dci_nr_freq_resource_size(cfg->pdsch_alloc_type, cfg->nof_rb_groups, cfg->bwp_dl_active_bw);
-  printf("dci_size: %u, frequency_resource added size: %u\n", count, dci_nr_freq_resource_size(cfg->pdsch_alloc_type, cfg->nof_rb_groups, cfg->bwp_dl_active_bw));
+  // printf("dci_size: %u, frequency_resource added size: %u\n", count, dci_nr_freq_resource_size(cfg->pdsch_alloc_type, cfg->nof_rb_groups, cfg->bwp_dl_active_bw));
 
   // Time domain resource assignment – 0, 1, 2, 3, or 4 bits
   count += dci_nr_time_res_size(cfg->nof_dl_time_res);
-  printf("dci_size: %u, time_resource added size: %u\n", count, dci_nr_time_res_size(cfg->nof_dl_time_res));
+  // printf("dci_size: %u, time_resource added size: %u\n", count, dci_nr_time_res_size(cfg->nof_dl_time_res));
 
   // VRB-to-PRB mapping – 0 or 1
   if (cfg->pdsch_alloc_type != srsran_resource_alloc_type0 && cfg->pdsch_inter_prb_to_prb) {
     count += 1;
   }
-  printf("dci_size: %u, vrb_prb_mapping added size: %u\n", count, cfg->pdsch_alloc_type != srsran_resource_alloc_type0 && cfg->pdsch_inter_prb_to_prb);
+  // printf("dci_size: %u, vrb_prb_mapping added size: %u\n", count, cfg->pdsch_alloc_type != srsran_resource_alloc_type0 && cfg->pdsch_inter_prb_to_prb);
 
   // PRB bundling size indicator – 0 or 1 bits
   // ... not implemented
-  printf("dci_size: %u, prb_bundling added size: %u (not implemented)\n", count, 0);
+  // printf("dci_size: %u, prb_bundling added size: %u (not implemented)\n", count, 0);
 
   // Rate matching indicator – 0, 1, or 2 bits
   if (cfg->pdsch_rm_pattern1) {
@@ -1384,43 +1384,43 @@ static uint32_t dci_nr_format_1_1_sizeof(const srsran_dci_cfg_nr_t* cfg, srsran_
   if (cfg->pdsch_rm_pattern2) {
     count += 1;
   }
-  printf("dci_size: %u, rate matching added size: %u\n", count, cfg->pdsch_rm_pattern1?1:0 + cfg->pdsch_rm_pattern2?1:0);
+  // printf("dci_size: %u, rate matching added size: %u\n", count, cfg->pdsch_rm_pattern1?1:0 + cfg->pdsch_rm_pattern2?1:0);
 
   // ZP CSI-RS trigger - 0, 1, or 2 bits
   count += (int)SRSRAN_CEIL_LOG2(cfg->nof_aperiodic_zp + 1);
-  printf("dci_size: %u, zp_csi_rs_trigger added size: %u\n", count, (int)SRSRAN_CEIL_LOG2(cfg->nof_aperiodic_zp + 1));
+  // printf("dci_size: %u, zp_csi_rs_trigger added size: %u\n", count, (int)SRSRAN_CEIL_LOG2(cfg->nof_aperiodic_zp + 1));
 
   // For transport block 1:
   // Modulation and coding scheme – 5 bits
   count += 5;
-  printf("dci_size: %u, mcs added size: %u\n", count, 5);
+  // printf("dci_size: %u, mcs added size: %u\n", count, 5);
 
   // New data indicator – 1 bit
   count += 1;
-  printf("dci_size: %u, new_data_indicator added size: %u\n", count, 1);
+  // printf("dci_size: %u, new_data_indicator added size: %u\n", count, 1);
 
   // Redundancy version – 2 bits
   count += 2;
-  printf("dci_size: %u, rv added size: %u\n", count, 2);
+  // printf("dci_size: %u, rv added size: %u\n", count, 2);
 
   // For transport block 2:
   if (cfg->pdsch_2cw) { // maybe enable this by default, since this is not optional in standards. But phone can work with srsgNB.
     // Modulation and coding scheme – 5 bits
     count += 5;
-    printf("dci_size: %u, tb2_modulation_coding_scheme added size: %u\n", count, 5);
+    // printf("dci_size: %u, tb2_modulation_coding_scheme added size: %u\n", count, 5);
 
     // New data indicator – 1 bit
     count += 1;
-    printf("dci_size: %u, tb2_new_data_indicator added size: %u\n", count, 1);
+    // printf("dci_size: %u, tb2_new_data_indicator added size: %u\n", count, 1);
 
     // Redundancy version – 2 bits
     count += 2;
-    printf("dci_size: %u, tb2_redundancy_version added size: %u\n", count, 2);
+    // printf("dci_size: %u, tb2_redundancy_version added size: %u\n", count, 2);
   }
 
   // HARQ process number – 4 bits
   count += 4;
-  printf("dci_size: %u, HARQ_process_number added size: %u\n", count, 4);
+  // printf("dci_size: %u, HARQ_process_number added size: %u\n", count, 4);
 
   // Downlink assignment index (dynamic HARQ-ACK codebook only)
   if (cfg->harq_ack_codebok == srsran_pdsch_harq_ack_codebook_dynamic) {
@@ -1430,47 +1430,47 @@ static uint32_t dci_nr_format_1_1_sizeof(const srsran_dci_cfg_nr_t* cfg, srsran_
       count += 2;
     }
   }
-  printf("dci_size: %u, DAI added size: %u\n", count, cfg->multiple_scell?4:2);
+  // printf("dci_size: %u, DAI added size: %u\n", count, cfg->multiple_scell?4:2);
 
   // TPC command for scheduled PUCCH – 2 bits
   count += 2;
-  printf("dci_size: %u, tpc added size: %u\n", count, 2);
+  // printf("dci_size: %u, tpc added size: %u\n", count, 2);
 
   // PUCCH resource indicator – 3 bits
   count += 3;
-  printf("dci_size: %u, PUCCH resource indicator added size: %u\n", count, 3);
+  // printf("dci_size: %u, PUCCH resource indicator added size: %u\n", count, 3);
 
   // PDSCH-to-HARQ_feedback timing indicator – 0, 1, 2, or 3 bits
   count += (int)SRSRAN_CEIL_LOG2(cfg->nof_dl_to_ul_ack);
-  printf("dci_size: %u, PDSCH-to-HARQ_feedback  added size: %u\n", count, (int)SRSRAN_CEIL_LOG2(cfg->nof_dl_to_ul_ack));
+  // printf("dci_size: %u, PDSCH-to-HARQ_feedback  added size: %u\n", count, (int)SRSRAN_CEIL_LOG2(cfg->nof_dl_to_ul_ack));
 
   // Antenna port(s) – 4, 5, or 6 bits
   count += dci_nr_dl_ports_size(cfg);
-  printf("dci_size: %u, antenna_ports added size: %u\n", count, dci_nr_dl_ports_size(cfg));
+  // printf("dci_size: %u, antenna_ports added size: %u\n", count, dci_nr_dl_ports_size(cfg));
 
   // Transmission configuration indication – 0 or 3 bits
   if (cfg->pdsch_tci) {
     count += 3;
   }
-  printf("dci_size: %u, pdsch_tci added size: %u\n", count, cfg->pdsch_tci?3:0);
+  // printf("dci_size: %u, pdsch_tci added size: %u\n", count, cfg->pdsch_tci?3:0);
 
   // SRS request – 2 or 3 bits
   count += cfg->enable_sul ? 3 : 2;
-  printf("dci_size: %u, srs_request added size: %u\n", count, cfg->enable_sul ? 3 : 2);
+  // printf("dci_size: %u, srs_request added size: %u\n", count, cfg->enable_sul ? 3 : 2);
 
   // CBG transmission information (CBGTI) – 0, 2, 4, 6, or 8 bits
   count += cfg->pdsch_nof_cbg;
-  printf("dci_size: %u, cbg_transmission_info added size: %u\n", count, cfg->pdsch_nof_cbg);
+  // printf("dci_size: %u, cbg_transmission_info added size: %u\n", count, cfg->pdsch_nof_cbg);
 
   // CBG flushing out information (CBGFI) – 0 or 1 bit
   if (cfg->pdsch_cbg_flush) {
     count += 1;
   }
-  printf("dci_size: %u, cbg_flushing_info added size: %u\n", count, cfg->pdsch_cbg_flush?1:0);
+  // printf("dci_size: %u, cbg_flushing_info added size: %u\n", count, cfg->pdsch_cbg_flush?1:0);
 
   // DMRS sequence initialization – 1 bit
   count += 1;
-  printf("dci_size: %u, dmrs_sequence_init added size: %u\n", count, 1);
+  // printf("dci_size: %u, dmrs_sequence_init added size: %u\n", count, 1);
 
   return count;
 }
@@ -1923,7 +1923,7 @@ int srsran_dci_nr_set_cfg(srsran_dci_nr_t* q, const srsran_dci_cfg_nr_t* cfg)
 
   q->dci_0_0_and_1_0_ue_size = SRSRAN_MAX(SRSRAN_MAX(size_dci_0_0_ue, size_dci_1_0_ue), DCI_NR_MIN_SIZE);
   if(!cfg->monitor_0_0_and_1_0){
-    printf("monitor_0_0_and_1_0 is disabled and we set the dci_0_0_and_1_0_ue_size with minimum possible size\n");
+    // printf("monitor_0_0_and_1_0 is disabled and we set the dci_0_0_and_1_0_ue_size with minimum possible size\n");
     q->dci_0_0_and_1_0_ue_size = DCI_NR_MIN_SIZE;
   }
   // Step 2
@@ -1939,7 +1939,7 @@ int srsran_dci_nr_set_cfg(srsran_dci_nr_t* q, const srsran_dci_cfg_nr_t* cfg)
     return SRSRAN_ERROR;
   }
 
-  printf("q->dci_0_0_and_1_0_ue_size: %u\n", q->dci_0_0_and_1_0_ue_size);
+  // printf("q->dci_0_0_and_1_0_ue_size: %u\n", q->dci_0_0_and_1_0_ue_size);
 
   // If the size of DCI format 0_1 monitored in a UE-specific search space equals that of a DCI format 0_0/1_0
   // monitored in another UE-specific search space, one bit of zero padding shall be appended to DCI format 0_1.

--- a/lib/src/phy/phch/pdcch_nr.c
+++ b/lib/src/phy/phch/pdcch_nr.c
@@ -991,7 +991,7 @@ int srsran_pdcch_nr_decode_with_rnti_nrscope_dciloop(srsran_pdcch_nr_t*      q,
   q->K = dci_msg->nof_bits + 24U;                                  // Payload size including CRC
   q->M = (1U << dci_msg->ctx.location.L) * (SRSRAN_NRE - 3U) * 6U; // Number of RE
   q->E = q->M * 2;                                                 // Number of Rate-Matched bits
-  printf("dci_msg->nof_bits: %d\n", dci_msg->nof_bits);
+  // printf("dci_msg->nof_bits: %d\n", dci_msg->nof_bits);
 
   // Check number of estimates is correct
   if (ce->nof_re != q->M) {
@@ -1050,7 +1050,7 @@ int srsran_pdcch_nr_decode_with_rnti_nrscope_dciloop(srsran_pdcch_nr_t*      q,
 
   // Descrambling
   srsran_sequence_apply_c(llr, llr, q->E, pdcch_nr_c_init(q, dci_msg));
-  printf("pdcch_nr_c_init(q, dci_msg): %u\n", pdcch_nr_c_init(q, dci_msg));
+  // printf("pdcch_nr_c_init(q, dci_msg): %u\n", pdcch_nr_c_init(q, dci_msg));
 
   // Un-rate matching
   int8_t* d = (int8_t*)q->d;
@@ -1130,11 +1130,11 @@ int srsran_pdcch_nr_decode_with_rnti_nrscope_dciloop(srsran_pdcch_nr_t*      q,
   uint32_t checksum2 = srsran_bit_pack(&ptr, 24);
   res->crc           = checksum1 == checksum2;
 
-  printf("CRC={%06x, %06x}; msg=", checksum1, checksum2);
-  srsran_vec_fprint_hex(stdout, c, dci_msg->nof_bits);
+  // printf("CRC={%06x, %06x}; msg=", checksum1, checksum2);
+  // srsran_vec_fprint_hex(stdout, c, dci_msg->nof_bits);
 
-  uint32_t checksum_diff = checksum1 > checksum2 ? checksum1 - checksum2 : checksum2 - checksum1;
-  printf("checksum diff: %u\n", checksum_diff);
+  // uint32_t checksum_diff = checksum1 > checksum2 ? checksum1 - checksum2 : checksum2 - checksum1;
+  // printf("checksum diff: %u\n", checksum_diff);
 
   uint8_t message_checksum[24] = {};
   uint8_t* ptr_message = message_checksum;

--- a/lib/src/phy/phch/pdcch_nr.c
+++ b/lib/src/phy/phch/pdcch_nr.c
@@ -991,6 +991,7 @@ int srsran_pdcch_nr_decode_with_rnti_nrscope_dciloop(srsran_pdcch_nr_t*      q,
   q->K = dci_msg->nof_bits + 24U;                                  // Payload size including CRC
   q->M = (1U << dci_msg->ctx.location.L) * (SRSRAN_NRE - 3U) * 6U; // Number of RE
   q->E = q->M * 2;                                                 // Number of Rate-Matched bits
+  printf("dci_msg->nof_bits: %d\n", dci_msg->nof_bits);
 
   // Check number of estimates is correct
   if (ce->nof_re != q->M) {
@@ -1049,7 +1050,7 @@ int srsran_pdcch_nr_decode_with_rnti_nrscope_dciloop(srsran_pdcch_nr_t*      q,
 
   // Descrambling
   srsran_sequence_apply_c(llr, llr, q->E, pdcch_nr_c_init(q, dci_msg));
-  // printf("pdcch_nr_c_init(q, dci_msg): %u\n", pdcch_nr_c_init(q, dci_msg));
+  printf("pdcch_nr_c_init(q, dci_msg): %u\n", pdcch_nr_c_init(q, dci_msg));
 
   // Un-rate matching
   int8_t* d = (int8_t*)q->d;
@@ -1129,11 +1130,11 @@ int srsran_pdcch_nr_decode_with_rnti_nrscope_dciloop(srsran_pdcch_nr_t*      q,
   uint32_t checksum2 = srsran_bit_pack(&ptr, 24);
   res->crc           = checksum1 == checksum2;
 
-  // printf("CRC={%06x, %06x}; msg=", checksum1, checksum2);
-  // srsran_vec_fprint_hex(stdout, c, dci_msg->nof_bits);
+  printf("CRC={%06x, %06x}; msg=", checksum1, checksum2);
+  srsran_vec_fprint_hex(stdout, c, dci_msg->nof_bits);
 
-  // uint32_t checksum_diff = checksum1 > checksum2 ? checksum1 - checksum2 : checksum2 - checksum1;
-  // printf("checksum diff: %u\n", checksum_diff);
+  uint32_t checksum_diff = checksum1 > checksum2 ? checksum1 - checksum2 : checksum2 - checksum1;
+  printf("checksum diff: %u\n", checksum_diff);
 
   uint8_t message_checksum[24] = {};
   uint8_t* ptr_message = message_checksum;

--- a/lib/src/phy/ue/ue_dl_nr.c
+++ b/lib/src/phy/ue/ue_dl_nr.c
@@ -1061,8 +1061,11 @@ static int ue_dl_nr_find_dci_ss_nrscope_dciloop(srsran_ue_dl_nr_t*           q,
         if (ue_dl_nr_find_dci_ncce_nrscope_dciloop(q, &dci_msg, &res, coreset_id, rnti) < SRSRAN_SUCCESS) {
           return SRSRAN_ERROR;
         }
-        // printf("res.crc: %u\n", res.crc);
-        // printf("dci_msg_rnti: %u\n", dci_msg.ctx.rnti);
+        printf("res.crc: %u\n", res.crc);
+        printf("dci_msg_rnti: %u\n", dci_msg.ctx.rnti);
+        printf("dci_msg.nof_bits: %u\n", dci_msg.nof_bits);
+        printf("dci_msg.payload:");
+        srsran_vec_fprint_hex(stdout, dci_msg.payload, dci_msg.nof_bits);
 
         // If the CRC was not match, move to next candidate
         if (!res.crc) {

--- a/lib/src/phy/ue/ue_dl_nr.c
+++ b/lib/src/phy/ue/ue_dl_nr.c
@@ -986,7 +986,6 @@ static int ue_dl_nr_find_dci_ss_nrscope_dciloop(srsran_ue_dl_nr_t*           q,
   for (uint32_t format_idx = 0; format_idx < SRSRAN_MIN(search_space->nof_formats, SRSRAN_DCI_FORMAT_NR_COUNT);
         format_idx++) {
     srsran_dci_format_nr_t dci_format = search_space->formats[format_idx];
-    printf("format_idx: %d\n", format_idx);
 
     // Calculate number of DCI bits
     uint32_t dci_nof_bits = srsran_dci_nr_size(&q->dci, search_space->type, dci_format);

--- a/lib/src/phy/ue/ue_dl_nr.c
+++ b/lib/src/phy/ue/ue_dl_nr.c
@@ -986,6 +986,7 @@ static int ue_dl_nr_find_dci_ss_nrscope_dciloop(srsran_ue_dl_nr_t*           q,
   for (uint32_t format_idx = 0; format_idx < SRSRAN_MIN(search_space->nof_formats, SRSRAN_DCI_FORMAT_NR_COUNT);
         format_idx++) {
     srsran_dci_format_nr_t dci_format = search_space->formats[format_idx];
+    printf("format_idx: %d\n", format_idx);
 
     // Calculate number of DCI bits
     uint32_t dci_nof_bits = srsran_dci_nr_size(&q->dci, search_space->type, dci_format);
@@ -1061,11 +1062,6 @@ static int ue_dl_nr_find_dci_ss_nrscope_dciloop(srsran_ue_dl_nr_t*           q,
         if (ue_dl_nr_find_dci_ncce_nrscope_dciloop(q, &dci_msg, &res, coreset_id, rnti) < SRSRAN_SUCCESS) {
           return SRSRAN_ERROR;
         }
-        printf("res.crc: %u\n", res.crc);
-        printf("dci_msg_rnti: %u\n", dci_msg.ctx.rnti);
-        printf("dci_msg.nof_bits: %u\n", dci_msg.nof_bits);
-        printf("dci_msg.payload:");
-        srsran_vec_fprint_hex(stdout, dci_msg.payload, dci_msg.nof_bits);
 
         // If the CRC was not match, move to next candidate
         if (!res.crc) {

--- a/nrscope/hdr/dci_decoder.h
+++ b/nrscope/hdr/dci_decoder.h
@@ -11,7 +11,8 @@ class DCIDecoder{
     srsran_sch_hl_cfg_nr_t pdsch_hl_cfg;
     srsran_sch_hl_cfg_nr_t pusch_hl_cfg;
     srsran_softbuffer_rx_t softbuffer;
-    srsran_dci_cfg_nr_t dci_cfg;
+    srsran_dci_cfg_nr_t dci_cfg; // DCI format without carrier aggregation
+    srsran_dci_cfg_nr_t dci_cfg_ca; // DCI format with carrier aggregation
     srsran_ue_dl_nr_args_t ue_dl_args;
     srsran_pdcch_cfg_nr_t  pdcch_cfg;
     

--- a/nrscope/src/libs/dci_decoder.cc
+++ b/nrscope/src/libs/dci_decoder.cc
@@ -65,12 +65,6 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
   }
   pdcch_cfg.coreset[0] = coreset0_t; 
 
-  // parameter settings
-  pdcch_cfg.search_space_present[0]      = true;
-  pdcch_cfg.search_space_present[1]      = false;
-  pdcch_cfg.search_space_present[2]      = false;
-  pdcch_cfg.ra_search_space_present      = false;
-
   asn1::rrc_nr::bwp_dl_ded_s * bwp_dl_ded_s_ptr = NULL;
   asn1::rrc_nr::bwp_ul_ded_s * bwp_ul_ded_s_ptr = NULL;
 
@@ -177,34 +171,39 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
     return SRSRAN_ERROR;
   }
 
-  if(bwp_dl_ded_s_ptr->pdcch_cfg.is_setup()){
-    pdcch_cfg.search_space[0].id = bwp_dl_ded_s_ptr->pdcch_cfg.setup().
-                                   search_spaces_to_add_mod_list[0].
-                                   search_space_id;
-    pdcch_cfg.search_space[0].coreset_id = bwp_dl_ded_s_ptr->pdcch_cfg.setup().
-                                           ctrl_res_set_to_add_mod_list[0].
-                                           ctrl_res_set_id;
-    
-    printf("pdcch_cfg.search_space[0].coreset_id in bwp%u: %u\n", bwp_id, 
-      pdcch_cfg.search_space[0].coreset_id);
+  pdcch_cfg.ra_search_space_present      = false;
 
-    pdcch_cfg.search_space[0].type = srsran_search_space_type_ue;
-    if(bwp_dl_ded_s_ptr->pdcch_cfg.setup().
-       search_spaces_to_add_mod_list[0].search_space_type.ue_specific().
-       dci_formats.formats0_minus1_and_minus1_minus1){
-      pdcch_cfg.search_space[0].formats[0] = srsran_dci_format_nr_1_1;
-      pdcch_cfg.search_space[0].formats[1] = srsran_dci_format_nr_0_1;
-      dci_cfg.monitor_0_0_and_1_0 = false;
-      dci_cfg.monitor_common_0_0 = false;
-    }else if(bwp_dl_ded_s_ptr->pdcch_cfg.setup().
-             search_spaces_to_add_mod_list[0].search_space_type.ue_specific().
-             dci_formats.formats0_minus0_and_minus1_minus0){
-      pdcch_cfg.search_space[0].formats[0] = srsran_dci_format_nr_1_0; 
-      pdcch_cfg.search_space[0].formats[1] = srsran_dci_format_nr_0_0;
-      dci_cfg.monitor_0_1_and_1_1 = false;
+  if(bwp_dl_ded_s_ptr->pdcch_cfg.is_setup()){
+    for (uint32_t ss_id = 0; ss_id < bwp_dl_ded_s_ptr->pdcch_cfg.setup().
+         search_spaces_to_add_mod_list.size(); ++ss_id) {
+      pdcch_cfg.search_space_present[ss_id] = true;
+      pdcch_cfg.search_space[ss_id].id = bwp_dl_ded_s_ptr->pdcch_cfg.setup().
+                                   search_spaces_to_add_mod_list[ss_id].
+                                   search_space_id;
+      pdcch_cfg.search_space[ss_id].coreset_id = bwp_dl_ded_s_ptr->pdcch_cfg.setup().
+                                            ctrl_res_set_to_add_mod_list[ss_id].
+                                            ctrl_res_set_id;
+      
+      printf("pdcch_cfg.search_space[%d].coreset_id in bwp%u: %u\n", ss_id, 
+        bwp_id, pdcch_cfg.search_space[ss_id].coreset_id);
+
+      pdcch_cfg.search_space[ss_id].type = srsran_search_space_type_ue;
+      if(bwp_dl_ded_s_ptr->pdcch_cfg.setup().
+        search_spaces_to_add_mod_list[ss_id].search_space_type.ue_specific().
+        dci_formats.formats0_minus1_and_minus1_minus1){
+        pdcch_cfg.search_space[ss_id].formats[0] = srsran_dci_format_nr_1_1;
+        pdcch_cfg.search_space[ss_id].formats[1] = srsran_dci_format_nr_0_1;
+        dci_cfg.monitor_0_0_and_1_0 = false;
+        dci_cfg.monitor_common_0_0 = false;
+      }else if(bwp_dl_ded_s_ptr->pdcch_cfg.setup().
+              search_spaces_to_add_mod_list[ss_id].search_space_type.
+              ue_specific().dci_formats.formats0_minus0_and_minus1_minus0){
+        pdcch_cfg.search_space[ss_id].formats[0] = srsran_dci_format_nr_1_0; 
+        pdcch_cfg.search_space[ss_id].formats[1] = srsran_dci_format_nr_0_0;
+        dci_cfg.monitor_0_1_and_1_1 = false;
+      }
+      pdcch_cfg.search_space[ss_id].nof_formats  = 2;
     }
-    pdcch_cfg.search_space[0].nof_formats  = 2;
-    pdcch_cfg.coreset[0] = coreset0_t; 
   }else{
     // Use some default settings
     pdcch_cfg.search_space[0].id           = 2;
@@ -215,8 +214,8 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
     dci_cfg.monitor_0_0_and_1_0 = false;
     dci_cfg.monitor_common_0_0 = false;
     pdcch_cfg.search_space[0].nof_formats  = 2;
-    pdcch_cfg.coreset[0] = coreset0_t; 
   }
+  pdcch_cfg.coreset[0] = coreset0_t; 
   
   // all the Coreset information is from RRCSetup
   for (uint32_t crst_id = 0; crst_id < bwp_dl_ded_s_ptr->pdcch_cfg.setup().
@@ -349,21 +348,25 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
   std::cout << "bwp_id: " << bwp_id << std::endl;
   
   // set ra search space directly from the RRC Setup
-  pdcch_cfg.search_space[0].nof_candidates[0] = bwp_dl_ded_s_ptr->
-    pdcch_cfg.setup().search_spaces_to_add_mod_list[0].
-    nrof_candidates.aggregation_level1;
-  pdcch_cfg.search_space[0].nof_candidates[1] = bwp_dl_ded_s_ptr->
-    pdcch_cfg.setup().search_spaces_to_add_mod_list[0].
-    nrof_candidates.aggregation_level2;
-  pdcch_cfg.search_space[0].nof_candidates[2] = bwp_dl_ded_s_ptr->
-    pdcch_cfg.setup().search_spaces_to_add_mod_list[0].
-    nrof_candidates.aggregation_level4;
-  pdcch_cfg.search_space[0].nof_candidates[3] = bwp_dl_ded_s_ptr->
-    pdcch_cfg.setup().search_spaces_to_add_mod_list[0].
-    nrof_candidates.aggregation_level8;
-  pdcch_cfg.search_space[0].nof_candidates[4] = bwp_dl_ded_s_ptr->
-    pdcch_cfg.setup().search_spaces_to_add_mod_list[0].
-    nrof_candidates.aggregation_level16;
+  for (uint32_t ss_id = 0; ss_id < bwp_dl_ded_s_ptr->
+    pdcch_cfg.setup().search_spaces_to_add_mod_list.size(); ss_id ++) {
+    pdcch_cfg.search_space[ss_id].nof_candidates[0] = bwp_dl_ded_s_ptr->
+      pdcch_cfg.setup().search_spaces_to_add_mod_list[ss_id].
+      nrof_candidates.aggregation_level1;
+    pdcch_cfg.search_space[ss_id].nof_candidates[1] = bwp_dl_ded_s_ptr->
+      pdcch_cfg.setup().search_spaces_to_add_mod_list[ss_id].
+      nrof_candidates.aggregation_level2;
+    pdcch_cfg.search_space[ss_id].nof_candidates[2] = bwp_dl_ded_s_ptr->
+      pdcch_cfg.setup().search_spaces_to_add_mod_list[ss_id].
+      nrof_candidates.aggregation_level4;
+    pdcch_cfg.search_space[ss_id].nof_candidates[3] = bwp_dl_ded_s_ptr->
+      pdcch_cfg.setup().search_spaces_to_add_mod_list[ss_id].
+      nrof_candidates.aggregation_level8;
+    pdcch_cfg.search_space[ss_id].nof_candidates[4] = bwp_dl_ded_s_ptr->
+      pdcch_cfg.setup().search_spaces_to_add_mod_list[ss_id].
+      nrof_candidates.aggregation_level16;
+  }
+  
   // } else {
   //   std::cout << "common" << std::endl;
   //   pdcch_cfg.search_space[0].nof_candidates[0] = sib1.serving_cell_cfg_common.
@@ -385,7 +388,7 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
   
 
   /* for carrier aggregation, we don't consider this situation. */
-  dci_cfg.carrier_indicator_size = 0; 
+  dci_cfg.carrier_indicator_size = 3; 
   
   /* if the supplementary_ul in sp_cell_cfg_ded is present. */
   dci_cfg.enable_sul = false; 
@@ -597,7 +600,6 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
   // For DCI 0_1
   ///< Set to true if HARQ-ACK codebook is set to dynamic with 2 sub-codebooks
   dci_cfg.dynamic_dual_harq_ack_codebook = false;
-
   dci_cfg.nof_dl_bwp = master_cell_group.sp_cell_cfg.sp_cell_cfg_ded.
     dl_bwp_to_add_mod_list.size();
   dci_cfg.nof_dl_time_res = bwp_dl_ded_s_ptr->pdsch_cfg.setup().
@@ -609,10 +611,30 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
     );
   dci_cfg.nof_aperiodic_zp = bwp_dl_ded_s_ptr->pdsch_cfg.setup().
     aperiodic_zp_csi_rs_res_sets_to_add_mod_list.size();
-  dci_cfg.pdsch_nof_cbg = bwp_dl_ded_s_ptr->pdsch_cfg.setup().
-    max_nrof_code_words_sched_by_dci_present ? 
-    bwp_dl_ded_s_ptr->pdsch_cfg.setup().
-    max_nrof_code_words_sched_by_dci : 0;
+  // maxCodeBlockGroupsPerTransportBlock
+  if (master_cell_group.sp_cell_cfg.sp_cell_cfg_ded.
+      pdsch_serving_cell_cfg_present && master_cell_group.sp_cell_cfg.
+      sp_cell_cfg_ded.pdsch_serving_cell_cfg_present) {
+    switch(master_cell_group.sp_cell_cfg.
+      sp_cell_cfg_ded.pdsch_serving_cell_cfg.setup().code_block_group_tx.
+      setup().max_code_block_groups_per_transport_block) {
+      case asn1::rrc_nr::pdsch_code_block_group_tx_s::
+           max_code_block_groups_per_transport_block_e_::n2: 
+        dci_cfg.pdsch_nof_cbg = 2;
+        break;
+      case asn1::rrc_nr::pdsch_code_block_group_tx_s::
+           max_code_block_groups_per_transport_block_e_::n4: 
+        dci_cfg.pdsch_nof_cbg = 4;
+        break;
+      case asn1::rrc_nr::pdsch_code_block_group_tx_s::
+           max_code_block_groups_per_transport_block_e_::n8: 
+        dci_cfg.pdsch_nof_cbg = 8;
+        break;
+      default:
+        dci_cfg.pdsch_nof_cbg = 0;
+        break;
+    }
+  }
   dci_cfg.nof_dl_to_ul_ack = bwp_ul_ded_s_ptr->pucch_cfg.setup().
     dl_data_to_ul_ack.size();
   dci_cfg.pdsch_inter_prb_to_prb = bwp_dl_ded_s_ptr->pdsch_cfg.setup().
@@ -630,8 +652,7 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
     }
   }
 
-  // Only consider one serving cell
-  dci_cfg.multiple_scell = false; 
+  dci_cfg.multiple_scell = true; 
   dci_cfg.pdsch_tci = bwp_dl_ded_s_ptr->pdcch_cfg.setup().
     ctrl_res_set_to_add_mod_list[0].tci_present_in_dci_present ? true : false; 
   dci_cfg.pdsch_cbg_flush = master_cell_group.sp_cell_cfg.
@@ -898,6 +919,7 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
     sp_cell_cfg_ded.pdsch_serving_cell_cfg.setup().max_mimo_layers_present ?
     master_cell_group.sp_cell_cfg.sp_cell_cfg_ded.pdsch_serving_cell_cfg.
     setup().max_mimo_layers : 4 : 4;
+  printf("carrier_dl.max_mimo_layer: %d\n", carrier_dl.max_mimo_layers);
   
   carrier_ul = base_carrier;
   carrier_ul.nof_prb = dci_cfg.bwp_ul_active_bw;

--- a/nrscope/src/libs/dci_decoder.cc
+++ b/nrscope/src/libs/dci_decoder.cc
@@ -919,12 +919,10 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
     sp_cell_cfg_ded.pdsch_serving_cell_cfg.setup().max_mimo_layers_present ?
     master_cell_group.sp_cell_cfg.sp_cell_cfg_ded.pdsch_serving_cell_cfg.
     setup().max_mimo_layers : 4 : 4;
-  printf("carrier_dl.max_mimo_layer: %d\n", carrier_dl.max_mimo_layers);
   
   carrier_ul = base_carrier;
   carrier_ul.nof_prb = dci_cfg.bwp_ul_active_bw;
   carrier_ul.max_mimo_layers = dci_cfg.nof_ul_layers;
-  printf("carrier_ul.max_mimo_layers: %d\n", carrier_ul.max_mimo_layers);
 
   dci_cfg.nof_rb_groups = 0;
   if(dci_cfg.pdsch_alloc_type == srsran_resource_alloc_type0){
@@ -992,8 +990,8 @@ int DCIDecoder::DecodeandParseDCIfromSlot(srsran_slot_cfg_t* slot,
     n_rntis = rnti_e - rnti_s;
   }
 
-  std::cout << "DCI decoder " << dci_decoder_id 
-    << " processing: [" << rnti_s << ", " << rnti_e << ")" << std::endl;
+  // std::cout << "DCI decoder " << dci_decoder_id 
+  //   << " processing: [" << rnti_s << ", " << rnti_e << ")" << std::endl;
 
   DCIFeedback new_result;
   sharded_results[dci_decoder_id] = new_result;

--- a/nrscope/src/libs/nrscope_logger.cc
+++ b/nrscope/src/libs/nrscope_logger.cc
@@ -26,7 +26,7 @@ namespace NRScopeLog{
         "tb_scaling_field,modulation,mcs_index,transport_block_size,code_rate,"
         "redundancy_version,new_data_indicator,nof_re,nof_bits,mcs_table,"
         "xoverhead,harq_id,downlink_assignment_index,tpc,pucch_resource,"
-        "harq_feedback,bwp,ports");
+        "harq_feedback,bwp,ports,carrier_index");
       fclose(pFile);
     }
     run_log = true;
@@ -72,7 +72,7 @@ namespace NRScopeLog{
     }
 
     snprintf(buff, sizeof(buff), "%f,%d,%d,%d,%s,%s,%d,%s,%d,%d,%d,%d,%d,%f,%d,"
-            "%d,%d,%s,%d,%d,%f,%d,%d,%d,%d,%s,%s,%d,%d,%d,%d,%d,%d,%d", 
+            "%d,%d,%s,%d,%d,%f,%d,%d,%d,%d,%s,%s,%d,%d,%d,%d,%d,%d,%d,%d", 
             input_node.timestamp,
             input_node.system_frame_idx,
             input_node.slot_idx,
@@ -112,7 +112,9 @@ namespace NRScopeLog{
               "1_1" ? input_node.dl_dci.harq_feedback : 0,
             input_node.bwp_id,
             input_node.dci_format == 
-              "1_1" ? input_node.dl_dci.ports : input_node.ul_dci.ports
+              "1_1" ? input_node.dl_dci.ports : input_node.ul_dci.ports,
+            input_node.dci_format == 
+              "1_1" ? input_node.dl_dci.cc_id : input_node.ul_dci.cc_id
     );
     FILE* pFile = fopen(filename[rf_index].c_str(), "a");
     

--- a/nrscope/src/libs/nrscope_worker.cc
+++ b/nrscope/src/libs/nrscope_worker.cc
@@ -377,9 +377,9 @@ void NRScopeWorker::Run() {
       }
       gettimeofday(&t1, NULL);
       std::cout << "sf_round: " << (int)slot_result.sf_round
-      << "sfn: " << (int)slot_result.outcome.sfn 
-      << "slot: " << (int)slot_result.slot.idx 
-      << "time: " << (int)(t1.tv_usec - t0.tv_usec) << std::endl;
+      << ", sfn: " << (int)slot_result.outcome.sfn 
+      << ", slot: " << (int)slot_result.slot.idx 
+      << ", time: " << (int)(t1.tv_usec - t0.tv_usec) << std::endl;
     }
 
     if(sibs_thread.joinable()){

--- a/nrscope/src/libs/radio_nr.cc
+++ b/nrscope/src/libs/radio_nr.cc
@@ -784,10 +784,10 @@ int Radio::FetchAndResample(){
       srsran::rf_buffer_t(rx_buffer + (pre_resampling_sf_sz * 
       (next_produce_at % RING_BUF_MODULUS + 1)), pre_resampling_sf_sz); 
 
-    std::cout << "current_produce_at: " << (!in_sync ? 0 : 
-        (next_produce_at % RING_BUF_MODULUS + 1)) << std::endl;
-    std::cout << "current_produce_ptr: " << (rf_buffer_t.to_cf_t())[0] << 
-        std::endl;
+    // std::cout << "current_produce_at: " << (!in_sync ? 0 : 
+    //     (next_produce_at % RING_BUF_MODULUS + 1)) << std::endl;
+    // std::cout << "current_produce_ptr: " << (rf_buffer_t.to_cf_t())[0] << 
+    //     std::endl;
 
     /* note fetching the raw samples will temporarily touch area out of the 
       target sf boundary yet after resampling, all meaningful data will reside 

--- a/nrscope/src/libs/radio_nr.cc
+++ b/nrscope/src/libs/radio_nr.cc
@@ -832,8 +832,8 @@ int Radio::DecodeAndProcess(){
   task_scheduler_nrscope.task_scheduler_state.sib1_inited = true;
   while (true) {
     sem_wait(&smph_sf_data_prod_cons); 
-    std::cout << "current_consume_at: " << (first_time ? 0 : 
-      ((next_consume_at % RING_BUF_MODULUS + 1))) << std::endl;
+    // std::cout << "current_consume_at: " << (first_time ? 0 : 
+    //   ((next_consume_at % RING_BUF_MODULUS + 1))) << std::endl;
     outcome.timestamp = last_rx_time.get(0);  
     struct timeval t0, t1;
     gettimeofday(&t0, NULL);
@@ -854,16 +854,16 @@ int Radio::DecodeAndProcess(){
         RING_BUF_MODULUS sf index; we copy wanted data to 0 sf idx
         assumption: no way when we are decoding this sf the fetch thread has 
         go around the whole ring and modify this sf again */
-      std::cout << "pre_resampling_sf_sz: " << pre_resampling_sf_sz 
-        << std::endl;
+      // std::cout << "pre_resampling_sf_sz: " << pre_resampling_sf_sz 
+      //   << std::endl;
       srsran_vec_cf_copy(rx_buffer, rx_buffer + 
         (first_time ? 0 : ((next_consume_at % RING_BUF_MODULUS + 1) * 
         pre_resampling_sf_sz)) + (slot_idx * slot_sz), slot_sz);
 
-      std::cout << "decode slot: " << (int) slot.idx << "; current_consume_ptr: " 
-        << rx_buffer + (first_time ? 0 : 
-        ((next_consume_at % RING_BUF_MODULUS + 1) * pre_resampling_sf_sz)) + 
-        (slot_idx * slot_sz) << std::endl; 
+      // std::cout << "decode slot: " << (int) slot.idx << "; current_consume_ptr: " 
+      //   << rx_buffer + (first_time ? 0 : 
+      //   ((next_consume_at % RING_BUF_MODULUS + 1) * pre_resampling_sf_sz)) + 
+      //   (slot_idx * slot_sz) << std::endl; 
 
       if (first_time) {
         /* If the next result is not set */

--- a/nrscope/src/libs/to_google.cc
+++ b/nrscope/src/libs/to_google.cc
@@ -192,6 +192,9 @@ namespace ToGoogle{
           pInt = PyLong_FromLong(new_entry.dci_format == "1_1" ? 
             new_entry.dl_dci.ports : new_entry.ul_dci.ports),
           PyDict_SetItemString(pDict, "ports", pInt);
+          pInt = PyLong_FromLong(new_entry.dci_format == "1_1" ? 
+            new_entry.dl_dci.cc_id : new_entry.ul_dci.cc_id),
+          PyDict_SetItemString(pDict, "carrier_index", pInt);
 
           PyList_SetItem(pList[rf_id], list_count[rf_id], pDict);
           list_count[rf_id] += 1;

--- a/nrscope/src/libs/to_google.py
+++ b/nrscope/src/libs/to_google.py
@@ -86,6 +86,7 @@ def create_table_with_position_and_time(credential, dataset_id_input, nof_usrp):
           bigquery.SchemaField("harq_feedback", "INTEGER", mode="REQUIRED"),
           bigquery.SchemaField("bwp", "INTEGER", mode="REQUIRED"),
           bigquery.SchemaField("ports", "INTEGER", mode="REQUIRED"),
+          bigquery.SchemaField("carrier_index", "INTEGER", mode="REQUIRED"),
       ]
 
       table = bigquery.Table(table_id, schema=schema)

--- a/nrscope/src/tests/CMakeLists.txt
+++ b/nrscope/src/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 add_executable(test_comm test_comm_path.cc)
 add_executable(google_client google_client_test.cc)
 add_executable(google_client_cc google_client_cc_test.cc)
+add_executable(rrc_reconf_test rrc_reconf_test.cc)
 
 target_link_libraries(test_comm srsue_phy
                                 srsran_common
@@ -39,7 +40,20 @@ target_link_libraries(google_client_cc srsue_phy
                                        ${SRSRAN_SOURCES}
                                        ${CMAKE_THREAD_LIBS_INIT}
                                        ${Boost_LIBRARIES}
-                                       ${YAML_CPP_LIBRARIES})                                
+                                       ${YAML_CPP_LIBRARIES})    
+                                       
+target_link_libraries(rrc_reconf_test srsue_phy
+                                      srsran_common
+                                      srsran_phy
+                                      srsran_radio
+                                      rrc_nr_asn1
+                                      nrscope_libs
+                                      test_libs
+                                      ${SRSUE_SOURCES} 
+                                      ${SRSRAN_SOURCES}
+                                      ${CMAKE_THREAD_LIBS_INIT}
+                                      ${Boost_LIBRARIES}
+                                      ${YAML_CPP_LIBRARIES}) 
 
 if(PUSH_TO_GOOGLE)
   target_link_libraries(google_client ${PYTHON_LIBRARIES})


### PR DESCRIPTION
Now NR-Scope can decode UE's DCI both with or without carrier aggregation (CA) within one cell. Given the RRC-Reconfiguration is encrypted, for each UE, NR-Scope tries the DCI format configuration both with/without CA enabled, where CA will add 3 or 5 bits to the DCI tested in the commercial cells around us. 

To track one UE across cells, one can use multiple USRP on one machine and edit the config.yaml file to listen to multiple cells simultaneously or run NR-Scope on multiple machines, then merge the log csv files across different instances of the NR-Scope.

Some of the settings are heuristic and based on our experience of commerical cell study, such as MSC table is selected to be 256QAM, which is true for all the commercial cells we see. If you find a mismatch between the decoded TBS and data rate for the UE, you can contact us for discussion.