### PR TITLE
Add rach log as a csv file

### DIFF
--- a/nrscope/hdr/nrscope_def.h
+++ b/nrscope/hdr/nrscope_def.h
@@ -159,6 +159,14 @@ typedef struct LogNode_ LogNode;
     uint8_t bwp_id;
   };
 
+typedef struct RACHLogNode_ RACHLogNode;
+  struct RACHLogNode_{
+    double timestamp;
+    int system_frame_idx;
+    int slot_idx;
+    uint16_t rnti;
+  };
+
 typedef struct ScanLogNode_ ScanLogNode;
   struct ScanLogNode_{
     uint32 gscn;

--- a/nrscope/hdr/nrscope_logger.h
+++ b/nrscope/hdr/nrscope_logger.h
@@ -23,6 +23,8 @@ namespace NRScopeLog{
 
   void push_node(ScanLogNode input_node, int rf_index);
 
+  void push_node(RACHLogNode input_node, int rf_index);
+
   /***
    * ...
    * 
@@ -31,6 +33,9 @@ namespace NRScopeLog{
   void write_entry(LogNode input_node, int rf_index);
 
   void write_entry(ScanLogNode input_node, int rf_index);
+
+  void write_entry(RACHLogNode input_node, int rf_index);
+
 
   /***
    * ...

--- a/nrscope/src/libs/task_scheduler.cc
+++ b/nrscope/src/libs/task_scheduler.cc
@@ -227,6 +227,14 @@ int TaskSchedulerNRScope::UpdatewithResult(SlotResult now_result) {
             now_result.new_rntis_found[i]);
           task_scheduler_state.last_seen.push_back(
             now);
+          RACHLogNode rach_log_node;
+          rach_log_node.timestamp = now;
+          rach_log_node.system_frame_idx = now_result.outcome.sfn;
+          rach_log_node.slot_idx = now_result.slot.idx;
+          rach_log_node.rnti = now_result.new_rntis_found[i];
+          if (local_log){
+            NRScopeLog::push_node(rach_log_node, rf_index);
+          }
         }
         task_scheduler_state.rach_found = true;
       } else {
@@ -247,6 +255,14 @@ int TaskSchedulerNRScope::UpdatewithResult(SlotResult now_result) {
               now_result.new_rntis_found[i]);
             task_scheduler_state.last_seen.push_back(
               now);
+            RACHLogNode rach_log_node;
+            rach_log_node.timestamp = now;
+            rach_log_node.system_frame_idx = now_result.outcome.sfn;
+            rach_log_node.slot_idx = now_result.slot.idx;
+            rach_log_node.rnti = now_result.new_rntis_found[i];
+            if (local_log){
+              NRScopeLog::push_node(rach_log_node, rf_index);
+            }
           }
         }
       }
@@ -269,7 +285,7 @@ int TaskSchedulerNRScope::UpdatewithResult(SlotResult now_result) {
             LogNode log_node;
             log_node.slot_idx = now_result.slot.idx;
             log_node.system_frame_idx = now_result.outcome.sfn;
-            log_node.timestamp = get_now_timestamp_in_double();
+            log_node.timestamp = now;
             log_node.grant = result.dl_grants[i];
             log_node.dci_format = 
               srsran_dci_format_nr_string(result.dl_dcis[i].ctx.format);
@@ -289,7 +305,7 @@ int TaskSchedulerNRScope::UpdatewithResult(SlotResult now_result) {
             LogNode log_node;
             log_node.slot_idx = now_result.slot.idx;
             log_node.system_frame_idx = now_result.outcome.sfn;
-            log_node.timestamp = get_now_timestamp_in_double();
+            log_node.timestamp = now;
             log_node.grant = result.ul_grants[i];
             log_node.dci_format = 
               srsran_dci_format_nr_string(result.ul_dcis[i].ctx.format);


### PR DESCRIPTION
NR-Scope will log the detected RACH as a separate `.csv` file, and the file name is the configured DCI file name + `_rach.csv`. For example, if the configured DCI file name is `a.csv`, the RACH log will be `a_rach.csv`. 
In this RACH log, each detected RACH behavior will be stored in a row with the `timestamp`, `system_frame_index`, `slot_index`, and `rnti`.