### PR TITLE
Added option to scan bands selectively

### DIFF
--- a/nrscope/config/config.yaml
+++ b/nrscope/config/config.yaml
@@ -1,6 +1,7 @@
 nof_usrp_dev: 1
 usrp_setting_0:
   ssb_freq: 622850000 # Set to the ssb frequency of the cell, could be obtained with the cell scan function
+  # band_list: [1,2,3,78] # Scan specific bands with the cell scan function. Will do full scan if left commented.
   rf_args: "clock=external,type=b200" # For B210
   # rf_args: "clock=external,type=x300,serial=32B0F2F,master_clock_rate=200000000,sampling_rate=25000000" ## For TwinRX daughterboard
   # rf_args: "clock=external,type=x300,sampling_rate=23040000" ## For CBX daughterboard

--- a/nrscope/hdr/radio_nr.h
+++ b/nrscope/hdr/radio_nr.h
@@ -3,6 +3,7 @@
 
 #include "cstdio"
 #include "memory"
+#include <vector>
 
 #include "nrscope/hdr/nrscope_def.h"
 #include "nrscope/hdr/rach_decoder.h"
@@ -42,7 +43,7 @@ class Radio{
     srsran_subcarrier_spacing_t                   ssb_scs;
     srsran::srsran_band_helper                    bands;
     srsran_ue_dl_nr_sratescs_info                 arg_scs;
-
+    std::vector<uint16_t>                         band_list;
     /* from cell_search.cc */
     srsue::nr::cell_search                        srsran_searcher; 
     srsue::nr::cell_search::cfg_t                 srsran_searcher_cfg_t;

--- a/nrscope/src/libs/load_config.cc
+++ b/nrscope/src/libs/load_config.cc
@@ -90,6 +90,14 @@ int load_config(std::vector<Radio>& radios, std::string file_name){
       }
       std::cout << "    AGC min_rx_gain: " << radios[i].min_rx_gain << std::endl;
 
+      if(config_yaml[setting_name]["band_list"]){
+        radios[i].band_list= config_yaml[setting_name]["band_list"].as<std::vector<uint16_t> >();
+        std::cout << "    band_list: ";
+        for(const auto& b : radios[i].band_list)
+          std::cout << b << "";
+        std::cout << std::endl;
+      }
+
       if(config_yaml[setting_name]["max_rx_gain"]){
         radios[i].max_rx_gain = 
           config_yaml[setting_name]["max_rx_gain"].as<float>();

--- a/nrscope/src/libs/radio_nr.cc
+++ b/nrscope/src/libs/radio_nr.cc
@@ -179,9 +179,23 @@ int Radio::ScanInitandStart(){
     }
   }
 
+  std::vector<srsran_band_helper::nr_band_ss_raster> scan_raster;
+  if (!band_list.empty()) {
+    for (const auto& b : band_list) {
+      for (const auto& entry : srsran_band_helper::nr_band_ss_raster_table) {
+        if (entry.band == b) {
+          scan_raster.push_back(entry);
+        }
+      }
+    }
+  } else {
+    scan_raster.assign(srsran_band_helper::nr_band_ss_raster_table.begin(),
+                        srsran_band_helper::nr_band_ss_raster_table.end());
+  }
+
+
   // Traverse GSCN per band
-  for (const srsran_band_helper::nr_band_ss_raster& ss_raster : 
-    srsran_band_helper::nr_band_ss_raster_table) {
+  for (const srsran_band_helper::nr_band_ss_raster& ss_raster : scan_raster) {
     std::cout << "Start scaning band " << ss_raster.band 
       << " with scs idx " << ss_raster.scs << std::endl;
     std::cout << "gscn " << ss_raster.gscn_first << " to gscn " 


### PR DESCRIPTION
Problem: Each time cell scan function is used, each possible NR band is scanned sequentially. This may not be desirable.
Solution: Added option in config file to select which bands to scan.
How to test: Uncomment band_list in config.yaml and enter desired bands like: "[1,3,78]"