### PR TITLE
Circular buffer for task dispatch & Bug fix & Specifying PCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ The main features are as follows:
 13. Non-initial (BWP id > 0) and plaintext (configured in SIB 1 or MSG 4) BWPs decoding in separate DCI decoder threads.
 14. Threaded resampling function for better-fidelity TwinRX USRP X310 daughterboard (better signal quality but doesn't support 5G sampling rate without resampling).
 15. Worker pool function is implemented. Each worker works on the slot data asynchronously. Now the processing doesn't need to keep up with the short slot time, and the throughput is increase through more workers.
-16. Stay tuned... 😄
+16. Band list can be configured for cell scan functions.
+17. A circular buffer is used for slot data dispatch among workers, now the CPU/worker number requirement is largely reduced.
+18. PCI can be configured in the config.yaml. If configured, NR-Scope will proceed only if the detected cell's PCI matches what is configured.
+19. Stay tuned... 😄
 
 Please refer to the [wiki page](https://github.com/PrincetonUniversity/NG-Scope-5G/wiki) for more feature description and documentation.
 
@@ -55,7 +58,7 @@ Please refer to the [wiki page](https://github.com/PrincetonUniversity/NG-Scope-
 
 If you are working with srsRAN base stations, please check out the `srsran` branch. The only difference is that during DCI decoding, the 64 QAM MCS table is selected, while the `main` branch uses 256 QAM MCS table, which is widely used in the commercial base stations. This MCS table information could be encrypted during the communication, thus it's set manually.
 
-The `main` branch will decode the DCIs based on the RRCSetup decoded during the RACH, and will try to decode DCIs both with and without carrier aggregation bits. According to our experience with T-Mobile cells, it can decode the DCIs for most of the UEs in the RAN. In the `fixed_rnti` branch, we add another worker group to manually include the RRCReconfiguration information in their DCI decoders, because the RRCReconfiguration is encrypted and can't be decoded by NR-Scope. In this case, NR-Scope can decode nearly all of the UEs in the cells we tested with (~ 99%). Also, you can set a known RNTI in the config file in `fixed_rnti` branch, then this RNTI will be assigned to the worker group using the manually configuered RRCReconfiguration. 
+The `main` branch will decode the DCIs based on the RRCSetup decoded during the RACH, and will try to decode DCIs both with and without carrier aggregation bits. According to our experience with T-Mobile cells, it can decode the DCIs for most of the UEs in the RAN. In the `fixed_rnti` branch, we add another worker group to manually include the RRCReconfiguration information in their DCI decoders, because the RRCReconfiguration is encrypted and can't be decoded by NR-Scope. In this case, NR-Scope can decode nearly all of the UEs in the cells we tested with (~ 99%). Also, you can set a known RNTI in the config file in `fixed_rnti` branch, then this RNTI will be assigned to the worker group using the manually configuered RRCReconfiguration.
 
 For a commercial cell, if you see a lot of RACH information but can't find further DCIs, this is because that the UEs are using updated configuration in the RRCReconfiguration. Please raise an issue and discuss with us, and if you could provide the RRCReconfiguration (from your phone), we can help you config NR-Scope properly.
 

--- a/lib/src/phy/rf/rf_uhd_imp.cc
+++ b/lib/src/phy/rf/rf_uhd_imp.cc
@@ -128,7 +128,7 @@ static const std::chrono::milliseconds RF_UHD_IMP_ASYNCH_MSG_SLEEP_MS = std::chr
 /**
  * Maximum of Rx Trials
  */
-static const uint32_t RF_UHD_IMP_MAX_RX_TRIALS = 100;
+static const uint32_t RF_UHD_IMP_MAX_RX_TRIALS = 400;
 
 /**
  * Timeout for end of burst ack.
@@ -709,6 +709,8 @@ static int uhd_init(rf_uhd_handler_t* handler, char* args, uint32_t nof_channels
       mcr = "122.88e6";
     } else if (device_addr["type"] == "e3x0") {
       mcr = "30.72e6";
+    } else if (device_addr["type"] == "x4xx") {
+      mcr = "245.76e6";
     }
 
     device_addr.set("master_clock_rate", mcr);

--- a/lib/src/phy/sync/ssb.c
+++ b/lib/src/phy/sync/ssb.c
@@ -467,6 +467,7 @@ int srsran_ssb_set_cfg(srsran_ssb_t* q, const srsran_ssb_cfg_t* cfg)
     return SRSRAN_ERROR;
   }
 
+  q->max_symbol_sz = 16668;
   // Verify symbol size
   if (q->max_symbol_sz < symbol_sz) {
     ERROR("New symbol size (%d) exceeds maximum symbol size (%d)", symbol_sz, q->max_symbol_sz);

--- a/nrscope/config/config.yaml
+++ b/nrscope/config/config.yaml
@@ -2,6 +2,7 @@ nof_usrp_dev: 1
 usrp_setting_0:
   ssb_freq: 622850000 # Set to the ssb frequency of the cell, could be obtained with the cell scan function
   # band_list: [1,2,3,78] # Scan specific bands with the cell scan function. Will do full scan if left commented.
+  # pci: 339 # Specify the desired Physical cell id. If specified, NR-Scope will proceed only if the decoded PCI matches this value.
   rf_args: "clock=external,type=b200" # For B210
   # rf_args: "clock=external,type=x300,serial=32B0F2F,master_clock_rate=200000000,sampling_rate=25000000" ## For TwinRX daughterboard
   # rf_args: "clock=external,type=x300,sampling_rate=23040000" ## For CBX daughterboard

--- a/nrscope/config/config_100mhz.yaml
+++ b/nrscope/config/config_100mhz.yaml
@@ -1,6 +1,8 @@
 nof_usrp_dev: 1
 usrp_setting_0:
   ssb_freq: 2506950000 # Set to the ssb frequency of the cell, could be obtained with the cell scan function
+  # band_list: [1,2,3,78] # Scan specific bands with the cell scan function. Will do full scan if left commented.
+  # pci: 339 # Specify the desired Physical cell id. If specified, NR-Scope will proceed only if the decoded PCI matches this value.
   rf_args: "clock=external,type=x300" # For B210
   # rf_args: "clock=external,type=x300,serial=32B0F2F,master_clock_rate=200000000,sampling_rate=25000000" ## For TwinRX daughterboard
   # rf_args: "clock=external,type=x300,sampling_rate=23040000" ## For CBX daughterboard

--- a/nrscope/config/config_twinrx.yaml
+++ b/nrscope/config/config_twinrx.yaml
@@ -1,5 +1,7 @@
 usrp_setting_0:
   ssb_freq: 622850000 # Set to the ssb frequency of the cell, could be obtained with the cell scan function
+  # band_list: [1,2,3,78] # Scan specific bands with the cell scan function. Will do full scan if left commented.
+  # pci: 339 # Specify the desired Physical cell id. If specified, NR-Scope will proceed only if the decoded PCI matches this value.
   rf_args: "clock=external,type=x300,serial=32B0F2F,master_clock_rate=200000000,sampling_rate=20000000" # For TwinRX daughterboard
   # rf_args: "clock=external,type=x300,sampling_rate=23040000" #"type=x300" #"clock=external" # For CBX daughterboard
   rx_gain: 70 # for x310 CBX, max rx gain is 31.5, for b210, it's around 80, for x310 TwinRX, max rx gain is 90

--- a/nrscope/hdr/nrscope_def.h
+++ b/nrscope/hdr/nrscope_def.h
@@ -268,13 +268,27 @@ typedef struct SlotResult_ SlotResult;
     /* The + operator depends on the SCS, so it's not defined here. */
   };
 
+typedef struct SlotData_ SlotData;
+  struct SlotData_{
+    std::atomic<bool> processed;
+    uint64_t sf_round;
+    srsran_slot_cfg_t slot;
+    srsran_ue_sync_nr_outcome_t outcome;
+    uint32_t slot_size;
+    cf_t* rx_buffer;
+  };
+
 bool CompareSlotResult (SlotResult a, SlotResult b);
 
 namespace NRScopeTask{
   extern std::vector<SlotResult> global_slot_results;
   extern std::mutex queue_lock;
+  extern std::mutex slot_data_lock;
   extern std::mutex task_scheduler_lock;
   extern std::mutex worker_locks[128];
+
+  extern sem_t smph_data;   // counts ready slots
+  extern sem_t smph_idle;   // counts idle workers
 }
 
 

--- a/nrscope/hdr/nrscope_worker.h
+++ b/nrscope/hdr/nrscope_worker.h
@@ -21,7 +21,7 @@ public:
 
   /* Job indicator */
   sem_t smph_has_job; 
-  bool busy;
+  std::atomic<bool> busy;
   int worker_id;
 
   /* Worker thread */

--- a/nrscope/hdr/radio_nr.h
+++ b/nrscope/hdr/radio_nr.h
@@ -74,6 +74,7 @@ class Radio{
     /* a better coordination between producer (fetch) and consumer 
        (resample and decode) */
     sem_t smph_sf_data_prod_cons;
+    sem_t smph_sf_data_finished;
 
     bool resample_needed;
     resampler_kit rk[RESAMPLE_WORKER_NUM];

--- a/nrscope/hdr/radio_nr.h
+++ b/nrscope/hdr/radio_nr.h
@@ -44,6 +44,7 @@ class Radio{
     srsran::srsran_band_helper                    bands;
     srsran_ue_dl_nr_sratescs_info                 arg_scs;
     std::vector<uint16_t>                         band_list;
+    uint16_t                                      pci;
     /* from cell_search.cc */
     srsue::nr::cell_search                        srsran_searcher; 
     srsue::nr::cell_search::cfg_t                 srsran_searcher_cfg_t;

--- a/nrscope/hdr/task_scheduler.h
+++ b/nrscope/hdr/task_scheduler.h
@@ -23,6 +23,13 @@ public:
   /* The next slot result that task_scheduler expects*/
   SlotResult next_result;
 
+  /* Slot data queue storage buffer */
+  std::vector<SlotData> slot_data;
+  std::atomic<uint32_t> slot_data_len;
+  std::atomic<uint32_t> next_slot_idx;
+  std::atomic<uint32_t> current_slot_idx;
+  std::thread task_thread;
+
   bool local_log;
   bool to_google;
   /* USRP's index */
@@ -55,11 +62,18 @@ public:
 
   void UpdateNextResult();
 
+  int ClaimIdleWorker();
+
   /* Assign the current slot to one worker*/
   int AssignTask(uint64_t sf_round,
                  srsran_slot_cfg_t slot, 
                  srsran_ue_sync_nr_outcome_t outcome,
                  cf_t* rx_buffer_);
+
+  int StoreSlotData(uint64_t sf_round,
+                    srsran_slot_cfg_t slot, 
+                    srsran_ue_sync_nr_outcome_t outcome,
+                    cf_t* rx_buffer_);
 
   /* resampler tools */
   float resample_ratio;
@@ -73,6 +87,7 @@ public:
 
 private:
   void Run();
+  void TasksDispatch();
 };
 
 }

--- a/nrscope/src/libs/dci_decoder.cc
+++ b/nrscope/src/libs/dci_decoder.cc
@@ -630,10 +630,7 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
       dci_cfg.pdsch_2cw = true;
     }
   }
-
-  /* for carrier aggregation*/
-  dci_cfg.carrier_indicator_size = 0; 
-  dci_cfg.multiple_scell = false; 
+  
 
   dci_cfg.pdsch_tci = bwp_dl_ded_s_ptr->pdcch_cfg.setup().
     ctrl_res_set_to_add_mod_list[0].tci_present_in_dci_present ? true : false; 
@@ -665,6 +662,15 @@ int DCIDecoder::DCIDecoderandReceptionInit(WorkState* state,
       break;
   }
   // std::cout << "pdsch resource alloc: " << dci_cfg.pdsch_alloc_type << std::endl;
+
+  // T-Mobile RRC Recfg
+  // dci_cfg.report_trigger_size = 2;
+  // dci_cfg.pdsch_alloc_type = srsran_resource_alloc_type1;
+  // dci_cfg.multiple_scell = true;
+
+  /* for non carrier aggregation*/
+  dci_cfg.multiple_scell = false;
+  dci_cfg.carrier_indicator_size = 0; 
 
   if(bwp_dl_ded_s_ptr->pdsch_cfg.setup().dmrs_dl_for_pdsch_map_type_a_present){
     if(bwp_dl_ded_s_ptr->pdsch_cfg.setup().dmrs_dl_for_pdsch_map_type_a.setup().

--- a/nrscope/src/libs/load_config.cc
+++ b/nrscope/src/libs/load_config.cc
@@ -94,8 +94,19 @@ int load_config(std::vector<Radio>& radios, std::string file_name){
         radios[i].band_list= config_yaml[setting_name]["band_list"].as<std::vector<uint16_t> >();
         std::cout << "    band_list: ";
         for(const auto& b : radios[i].band_list)
-          std::cout << b << "";
+          std::cout << b << " ";
         std::cout << std::endl;
+      }
+
+      if(config_yaml[setting_name]["pci"]){
+        radios[i].pci = config_yaml[setting_name]["pci"].as<uint16_t>();
+        if (radios[i].pci > 1007) {
+          ERROR("PCI ranges from 0 to 1007, are you doing it right?");
+        }
+        std::cout << "    pci: " << radios[i].pci << std::endl;
+      } else {
+        radios[i].pci = 9999; // PCI ranges from 0 to 1007, thus 9999 is invalid
+        // std::cout << "    pci: " << radios[i].pci << std::endl;
       }
 
       if(config_yaml[setting_name]["max_rx_gain"]){

--- a/nrscope/src/libs/nrscope_logger.cc
+++ b/nrscope/src/libs/nrscope_logger.cc
@@ -4,7 +4,7 @@ namespace NRScopeLog{
   std::vector<std::string> filename;
   std::vector<std::string> rach_filename;
   std::vector< std::queue<LogNode> > log_queue;
-  std::vector <std::queue<RACHLogNode> > rach_log_queue;
+  std::vector< std::queue<RACHLogNode> > rach_log_queue;
   std::vector< std::queue<ScanLogNode> > scan_log_queue;
   std::thread log_thread;
   std::mutex lock;


### PR DESCRIPTION
Some improvements have been made in this pull request:
* Now the code will maintain a circular buffer for task dispatching among workers, and the CPU/worker number requirement is largely reduced -- 8 workers can keep up with the 100MHz cell decoding.
* Now you can specify PCI in `config.yaml`. If configured, NR-Scope will proceed only if the detected cell's PCI matches the configured value.
* Some interface updates for X410 SDR, but more tests are needed.